### PR TITLE
Improve light/dark mode readability across landing page and components

### DIFF
--- a/components/ArrayVisualizer.jsx
+++ b/components/ArrayVisualizer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 
 function ArrayVisualizer({ initialArray = [10, 20, 30, 40, 50], highlightIndices = [], labels = {} }) {
     const [arr, setArr] = useState(initialArray);
@@ -24,7 +24,7 @@ function ArrayVisualizer({ initialArray = [10, 20, 30, 40, 50], highlightIndices
                                 <span style={{
                                     fontSize: "11px",
                                     fontWeight: 600,
-                                    color: "#6366f1",
+                                    color: "var(--comp-label-color)",
                                     fontFamily: "monospace",
                                 }}>
                                     {label}
@@ -37,13 +37,19 @@ function ArrayVisualizer({ initialArray = [10, 20, 30, 40, 50], highlightIndices
                                     display: "flex",
                                     alignItems: "center",
                                     justifyContent: "center",
-                                    border: isHighlighted ? "2px solid #6366f1" : "2px solid #d1d5db",
+                                    border: isHighlighted
+                                        ? "2px solid var(--comp-cell-highlight-border)"
+                                        : "2px solid var(--comp-cell-border)",
                                     borderRadius: "6px",
-                                    background: isHighlighted ? "#eef2ff" : "#f9fafb",
+                                    background: isHighlighted
+                                        ? "var(--comp-cell-highlight-bg)"
+                                        : "var(--comp-cell-bg)",
                                     fontFamily: "monospace",
                                     fontWeight: 600,
                                     fontSize: "16px",
-                                    color: isHighlighted ? "#4338ca" : "#374151",
+                                    color: isHighlighted
+                                        ? "var(--comp-cell-highlight-text)"
+                                        : "var(--comp-cell-text)",
                                     transition: "all 0.2s ease",
                                 }}
                             >
@@ -51,7 +57,7 @@ function ArrayVisualizer({ initialArray = [10, 20, 30, 40, 50], highlightIndices
                             </div>
                             <span style={{
                                 fontSize: "11px",
-                                color: "#9ca3af",
+                                color: "var(--comp-index-color)",
                                 fontFamily: "monospace",
                             }}>
                                 [{i}]
@@ -134,22 +140,24 @@ function InteractiveArray() {
 
     const inputStyle = {
         padding: "6px 10px",
-        border: "1px solid #d1d5db",
+        border: "1px solid var(--comp-input-border)",
         borderRadius: "6px",
         width: "80px",
         fontSize: "13px",
         fontFamily: "monospace",
+        background: "var(--comp-input-bg)",
+        color: "var(--comp-input-text)",
     };
 
     return (
         <div style={{
-            border: "1px solid #e5e7eb",
+            border: "1px solid var(--comp-border)",
             borderRadius: "10px",
             padding: "20px",
             margin: "16px 0",
-            background: "#fafafa",
+            background: "var(--comp-surface)",
         }}>
-            <div style={{ fontWeight: 600, marginBottom: "12px", fontSize: "14px", color: "#374151" }}>
+            <div style={{ fontWeight: 600, marginBottom: "12px", fontSize: "14px", color: "var(--comp-text-2)" }}>
                 Try it: Interactive Array
             </div>
             <ArrayVisualizer initialArray={arr} highlightIndices={highlighted} />
@@ -197,12 +205,12 @@ function InteractiveArray() {
                 <div style={{
                     marginTop: "10px",
                     padding: "8px 12px",
-                    background: "#f0fdf4",
-                    border: "1px solid #bbf7d0",
+                    background: "var(--comp-msg-bg)",
+                    border: "1px solid var(--comp-msg-border)",
                     borderRadius: "6px",
                     fontSize: "13px",
                     fontFamily: "monospace",
-                    color: "#166534",
+                    color: "var(--comp-msg-text)",
                 }}>
                     {message}
                 </div>

--- a/components/QuizBox.jsx
+++ b/components/QuizBox.jsx
@@ -21,18 +21,47 @@ function QuizBox({ question, options, correctIndex, explanation }) {
 
     const isCorrect = selected === correctIndex;
 
+    const getOptionStyle = (i) => {
+        if (showResult && i === correctIndex) {
+            return {
+                borderColor: "var(--comp-correct-border)",
+                background: "var(--comp-correct-bg)",
+                color: "var(--comp-correct-text)",
+            };
+        }
+        if (showResult && selected === i && i !== correctIndex) {
+            return {
+                borderColor: "var(--comp-wrong-border)",
+                background: "var(--comp-wrong-bg)",
+                color: "var(--comp-wrong-text)",
+            };
+        }
+        if (selected === i && !showResult) {
+            return {
+                borderColor: "var(--comp-selected-border)",
+                background: "var(--comp-selected-bg)",
+                color: "var(--comp-selected-text)",
+            };
+        }
+        return {
+            borderColor: "var(--comp-border-interactive)",
+            background: "var(--comp-surface-2)",
+            color: "var(--comp-text-2)",
+        };
+    };
+
     return (
         <div style={{
-            border: "1px solid #e5e7eb",
+            border: "1px solid var(--comp-border)",
             borderRadius: "10px",
             padding: "20px",
             margin: "16px 0",
-            background: "#fafafa",
+            background: "var(--comp-surface)",
         }}>
             <div style={{
                 fontWeight: 600,
                 fontSize: "14px",
-                color: "#1f2937",
+                color: "var(--comp-text)",
                 marginBottom: "14px",
                 lineHeight: "1.5",
             }}>
@@ -40,25 +69,7 @@ function QuizBox({ question, options, correctIndex, explanation }) {
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
                 {options.map((opt, i) => {
-                    let borderColor = "#d1d5db";
-                    let bg = "white";
-                    let textColor = "#374151";
-
-                    if (selected === i && !showResult) {
-                        borderColor = "#6366f1";
-                        bg = "#eef2ff";
-                    }
-                    if (showResult && i === correctIndex) {
-                        borderColor = "#16a34a";
-                        bg = "#f0fdf4";
-                        textColor = "#166534";
-                    }
-                    if (showResult && selected === i && i !== correctIndex) {
-                        borderColor = "#dc2626";
-                        bg = "#fef2f2";
-                        textColor = "#991b1b";
-                    }
-
+                    const optStyle = getOptionStyle(i);
                     return (
                         <button
                             key={i}
@@ -68,12 +79,12 @@ function QuizBox({ question, options, correctIndex, explanation }) {
                                 alignItems: "center",
                                 gap: "10px",
                                 padding: "10px 14px",
-                                border: `2px solid ${borderColor}`,
+                                border: `2px solid ${optStyle.borderColor}`,
                                 borderRadius: "8px",
-                                background: bg,
+                                background: optStyle.background,
                                 cursor: showResult ? "default" : "pointer",
                                 fontSize: "14px",
-                                color: textColor,
+                                color: optStyle.color,
                                 textAlign: "left",
                                 fontFamily: "inherit",
                                 transition: "all 0.15s ease",
@@ -84,14 +95,15 @@ function QuizBox({ question, options, correctIndex, explanation }) {
                                 width: "24px",
                                 height: "24px",
                                 borderRadius: "50%",
-                                border: `2px solid ${borderColor}`,
+                                border: `2px solid ${optStyle.borderColor}`,
                                 display: "flex",
                                 alignItems: "center",
                                 justifyContent: "center",
                                 fontSize: "12px",
                                 fontWeight: 600,
                                 flexShrink: 0,
-                                background: selected === i ? (showResult ? bg : "#eef2ff") : "white",
+                                background: selected === i ? optStyle.background : "var(--comp-surface-2)",
+                                color: optStyle.color,
                             }}>
                                 {String.fromCharCode(65 + i)}
                             </span>
@@ -109,7 +121,7 @@ function QuizBox({ question, options, correctIndex, explanation }) {
                             padding: "8px 20px",
                             border: "none",
                             borderRadius: "6px",
-                            background: selected === null ? "#d1d5db" : "#4f46e5",
+                            background: selected === null ? "var(--comp-border-interactive)" : "#4f46e5",
                             color: "white",
                             cursor: selected === null ? "not-allowed" : "pointer",
                             fontWeight: 500,
@@ -125,7 +137,7 @@ function QuizBox({ question, options, correctIndex, explanation }) {
                             padding: "8px 20px",
                             border: "none",
                             borderRadius: "6px",
-                            background: "#6b7280",
+                            background: "var(--comp-text-muted)",
                             color: "white",
                             cursor: "pointer",
                             fontWeight: 500,
@@ -141,11 +153,11 @@ function QuizBox({ question, options, correctIndex, explanation }) {
                     marginTop: "12px",
                     padding: "12px 14px",
                     borderRadius: "8px",
-                    background: isCorrect ? "#f0fdf4" : "#fef2f2",
-                    border: `1px solid ${isCorrect ? "#bbf7d0" : "#fecaca"}`,
+                    background: isCorrect ? "var(--comp-correct-bg)" : "var(--comp-wrong-bg)",
+                    border: `1px solid ${isCorrect ? "var(--comp-correct-border)" : "var(--comp-wrong-border)"}`,
                     fontSize: "13px",
                     lineHeight: "1.6",
-                    color: isCorrect ? "#166534" : "#991b1b",
+                    color: isCorrect ? "var(--comp-correct-text)" : "var(--comp-wrong-text)",
                 }}>
                     <strong>{isCorrect ? "Correct!" : "Not quite."}</strong>{" "}
                     {explanation}

--- a/components/ShowHideSolution.jsx
+++ b/components/ShowHideSolution.jsx
@@ -3,22 +3,21 @@ import React, { useState } from "react";
 function ShowHideSolution({ children }) {
     const [isHidden, setIsHidden] = useState(true);
 
-    const toggleVisibility = () => {
-        setIsHidden(!isHidden);
-    };
-
-    const buttonStyle = {
-        background: "black",
-        color: "white",
-        cursor: "pointer",
-        padding: "6px 12px",
-        border: "none",
-        borderRadius: "9px",
-    };
-
     return (
         <div>
-            <button style={buttonStyle} onClick={toggleVisibility}>
+            <button
+                onClick={() => setIsHidden(!isHidden)}
+                style={{
+                    background: "var(--comp-text)",
+                    color: "var(--comp-surface)",
+                    cursor: "pointer",
+                    padding: "6px 12px",
+                    border: "none",
+                    borderRadius: "9px",
+                    fontWeight: 500,
+                    fontSize: "13px",
+                }}
+            >
                 {isHidden ? "Show Solution" : "Hide Solution"}
             </button>
             {!isHidden && children}

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -27,14 +27,14 @@ import {
 {/* ──────────────────────── HERO ──────────────────────── */}
 
 <div className="relative overflow-hidden -mt-4">
-  <div className="absolute inset-0 -z-10 opacity-30 pointer-events-none">
-    <div className="absolute top-10 left-10 w-72 h-72 bg-blue-500/30 rounded-full blur-3xl" />
-    <div className="absolute top-40 right-10 w-72 h-72 bg-purple-500/30 rounded-full blur-3xl" />
-    <div className="absolute bottom-0 left-1/3 w-72 h-72 bg-teal-500/30 rounded-full blur-3xl" />
+  <div className="absolute inset-0 -z-10 opacity-20 dark:opacity-30 pointer-events-none">
+    <div className="absolute top-10 left-10 w-72 h-72 bg-blue-500/40 rounded-full blur-3xl" />
+    <div className="absolute top-40 right-10 w-72 h-72 bg-purple-500/40 rounded-full blur-3xl" />
+    <div className="absolute bottom-0 left-1/3 w-72 h-72 bg-teal-500/40 rounded-full blur-3xl" />
   </div>
 
   <div className="flex flex-col items-center justify-center text-center pt-16 pb-10 px-4">
-    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-blue-500/10 border border-blue-500/30 text-xs font-medium text-blue-300 mb-8 leading-none">
+    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-blue-500/10 border border-blue-500/30 text-xs font-medium text-blue-700 dark:text-blue-300 mb-8 leading-none">
       <span className="relative inline-flex w-2 h-2 shrink-0">
         <span className="animate-ping absolute inset-0 rounded-full bg-blue-400 opacity-75" />
         <span className="relative w-2 h-2 rounded-full bg-blue-400" />
@@ -48,22 +48,22 @@ import {
       aria-level={1}
     >
       <div className="pb-2 md:pb-3">The interview-prep guide that</div>
-      <div className="bg-clip-text text-transparent bg-gradient-to-r from-blue-400 via-purple-400 to-pink-400 pb-2">
+      <div className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 dark:from-blue-400 dark:via-purple-400 dark:to-pink-400 pb-2">
         actually sticks.
       </div>
     </div>
 
-    <p className="text-lg md:text-xl text-gray-400 max-w-2xl mb-2">
+    <p className="text-lg md:text-xl text-gray-600 dark:text-gray-400 max-w-2xl mb-2">
       Most DSA courses feel like reading a math textbook in a noisy library.
     </p>
-    <p className="text-lg md:text-xl text-gray-200 max-w-2xl mb-10 font-medium">
+    <p className="text-lg md:text-xl text-gray-900 dark:text-gray-200 max-w-2xl mb-10 font-medium">
       This one feels like playing a game — one level a day, for thirty days.
     </p>
 
     <div className="flex flex-wrap gap-3 justify-center mb-5">
       <Link
         href="/getting_started"
-        className="group inline-flex items-center gap-2 px-7 py-3 text-base font-semibold text-white bg-gradient-to-r from-blue-600 to-purple-600 rounded-full hover:shadow-lg hover:shadow-blue-500/50 transition-all duration-300 transform hover:-translate-y-0.5 leading-none"
+        className="group inline-flex items-center gap-2 px-7 py-3 text-base font-semibold text-white bg-gradient-to-r from-blue-600 to-purple-600 rounded-full hover:shadow-lg hover:shadow-blue-500/40 transition-all duration-300 transform hover:-translate-y-0.5 leading-none"
       >
         <LuRocket className="w-[18px] h-[18px] shrink-0" />
         <span>Start the Challenge</span>
@@ -71,14 +71,14 @@ import {
       </Link>
       <Link
         href="/day1"
-        className="inline-flex items-center gap-2 px-7 py-3 text-base font-semibold text-gray-200 bg-gray-800/70 backdrop-blur border border-gray-700 rounded-full hover:bg-gray-700 transition-all leading-none"
+        className="inline-flex items-center gap-2 px-7 py-3 text-base font-semibold text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-800/70 backdrop-blur border border-gray-300 dark:border-gray-700 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700/80 transition-all leading-none"
       >
         <LuBookOpen className="w-[18px] h-[18px] shrink-0" />
         <span>Jump to Day 1</span>
       </Link>
     </div>
 
-    <div className="inline-flex items-center gap-2 text-xs text-gray-500 leading-none">
+    <div className="inline-flex items-center gap-2 text-xs text-gray-500 dark:text-gray-500 leading-none">
       <LuLockOpen className="w-3.5 h-3.5 shrink-0" />
       <span>Free forever · No signup · Bookmark and bail any time</span>
     </div>
@@ -88,21 +88,21 @@ import {
 {/* ──────────────────────── STAT STRIP ──────────────────────── */}
 
 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-5xl mx-auto px-4 mb-24">
-  <div className="text-center p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-    <div className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-teal-400">30</div>
-    <div className="text-xs text-gray-400 mt-1">Days, end-to-end</div>
+  <div className="text-center p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+    <div className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-teal-600 dark:from-blue-400 dark:to-teal-400">30</div>
+    <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">Days, end-to-end</div>
   </div>
-  <div className="text-center p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-    <div className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-pink-400">150+</div>
-    <div className="text-xs text-gray-400 mt-1">Hand-picked problems</div>
+  <div className="text-center p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+    <div className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-purple-600 to-pink-600 dark:from-purple-400 dark:to-pink-400">150+</div>
+    <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">Hand-picked problems</div>
   </div>
-  <div className="text-center p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-    <div className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-amber-400 to-orange-400">3</div>
-    <div className="text-xs text-gray-400 mt-1">Languages — C++, Py, Java</div>
+  <div className="text-center p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+    <div className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-amber-600 to-orange-600 dark:from-amber-400 dark:to-orange-400">3</div>
+    <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">Languages — C++, Py, Java</div>
   </div>
-  <div className="text-center p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-    <div className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-green-400 to-emerald-400">0</div>
-    <div className="text-xs text-gray-400 mt-1">Paywalls, ever</div>
+  <div className="text-center p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+    <div className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-green-600 to-emerald-600 dark:from-green-400 dark:to-emerald-400">0</div>
+    <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">Paywalls, ever</div>
   </div>
 </div>
 
@@ -110,37 +110,37 @@ import {
 
 <div className="max-w-4xl mx-auto px-4 mb-24">
   <div className="text-center mb-10">
-    <div className="inline-block px-3 py-1 rounded-full bg-rose-500/10 border border-rose-500/30 text-xs font-medium text-rose-300 mb-4">
+    <div className="inline-block px-3 py-1 rounded-full bg-rose-500/10 border border-rose-500/30 text-xs font-medium text-rose-700 dark:text-rose-300 mb-4">
       SOUND FAMILIAR?
     </div>
     <h2 className="text-3xl md:text-4xl font-bold leading-tight">
-      You've studied DSA. <span className="text-rose-300">You still can't do it.</span>
+      You've studied DSA. <span className="text-rose-600 dark:text-rose-300">You still can't do it.</span>
     </h2>
   </div>
 
   <div className="space-y-3">
-    <div className="flex items-start gap-3 p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-      <LuCircleX className="w-5 h-5 text-rose-400 mt-0.5 shrink-0" />
-      <p className="text-gray-300">
-        You've watched <span className="font-semibold text-white">11 hours of YouTube</span> on recursion and still freeze when an interviewer says <em>"can you do it recursively?"</em>
+    <div className="flex items-start gap-3 p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+      <LuCircleX className="w-5 h-5 text-rose-500 dark:text-rose-400 mt-0.5 shrink-0" />
+      <p className="text-gray-700 dark:text-gray-300">
+        You've watched <span className="font-semibold text-gray-900 dark:text-white">11 hours of YouTube</span> on recursion and still freeze when an interviewer says <em>"can you do it recursively?"</em>
       </p>
     </div>
-    <div className="flex items-start gap-3 p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-      <LuCircleX className="w-5 h-5 text-rose-400 mt-0.5 shrink-0" />
-      <p className="text-gray-300">
-        You've read <span className="font-semibold text-white">the same Big-O cheat sheet six times</span>. You still pause for two seconds before you say "logarithmic."
+    <div className="flex items-start gap-3 p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+      <LuCircleX className="w-5 h-5 text-rose-500 dark:text-rose-400 mt-0.5 shrink-0" />
+      <p className="text-gray-700 dark:text-gray-300">
+        You've read <span className="font-semibold text-gray-900 dark:text-white">the same Big-O cheat sheet six times</span>. You still pause for two seconds before you say "logarithmic."
       </p>
     </div>
-    <div className="flex items-start gap-3 p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-      <LuCircleX className="w-5 h-5 text-rose-400 mt-0.5 shrink-0" />
-      <p className="text-gray-300">
-        You know what <span className="font-semibold text-white">dynamic programming</span> is. You still don't trust yourself to pick it on a brand new problem.
+    <div className="flex items-start gap-3 p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+      <LuCircleX className="w-5 h-5 text-rose-500 dark:text-rose-400 mt-0.5 shrink-0" />
+      <p className="text-gray-700 dark:text-gray-300">
+        You know what <span className="font-semibold text-gray-900 dark:text-white">dynamic programming</span> is. You still don't trust yourself to pick it on a brand new problem.
       </p>
     </div>
   </div>
 
-  <p className="text-center text-gray-400 mt-10 text-lg max-w-2xl mx-auto">
-    Reading about DSA isn't the same as <span className="text-white font-semibold">doing</span> DSA. This site forces the second one.
+  <p className="text-center text-gray-600 dark:text-gray-400 mt-10 text-lg max-w-2xl mx-auto">
+    Reading about DSA isn't the same as <span className="text-gray-900 dark:text-white font-semibold">doing</span> DSA. This site forces the second one.
   </p>
 </div>
 
@@ -148,20 +148,20 @@ import {
 
 <div className="max-w-4xl mx-auto px-4 mb-24">
   <div className="text-center mb-8">
-    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-purple-500/10 border border-purple-500/30 text-xs font-medium text-purple-300 mb-4 leading-none">
+    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-purple-500/10 border border-purple-500/30 text-xs font-medium text-purple-700 dark:text-purple-300 mb-4 leading-none">
       <LuFlaskConical className="w-3.5 h-3.5 shrink-0" />
       <span>LIVE DEMO — NO SCROLL, GO</span>
     </div>
     <h2 className="text-3xl md:text-4xl font-bold mb-3">
       Don't take our word for it. <br />
-      <span className="text-purple-400">Break the array yourself.</span>
+      <span className="text-purple-700 dark:text-purple-400">Break the array yourself.</span>
     </h2>
-    <p className="text-gray-400 max-w-xl mx-auto">
+    <p className="text-gray-600 dark:text-gray-400 max-w-xl mx-auto">
       Push. Pop. Insert. Search. Every page on this site has a widget like this one — concepts you can poke instead of memorize.
     </p>
   </div>
 
-  <div className="rounded-2xl border border-gray-800 bg-gray-950/60 p-2 shadow-2xl">
+  <div className="rounded-2xl border border-gray-200 dark:border-gray-800 bg-white/60 dark:bg-gray-950/60 p-2 shadow-md dark:shadow-2xl">
     <InteractiveArray />
   </div>
 </div>
@@ -170,14 +170,14 @@ import {
 
 <div className="max-w-3xl mx-auto px-4 mb-24">
   <div className="text-center mb-8">
-    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/10 border border-amber-500/30 text-xs font-medium text-amber-300 mb-4 leading-none">
+    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-amber-500/10 border border-amber-500/30 text-xs font-medium text-amber-700 dark:text-amber-300 mb-4 leading-none">
       <LuTarget className="w-3.5 h-3.5 shrink-0" />
       <span>ONE-QUESTION POP QUIZ</span>
     </div>
     <h2 className="text-3xl md:text-4xl font-bold mb-3">
       Think you've already got the basics?
     </h2>
-    <p className="text-gray-400">Prove it. One question. No login, no judgement, no shame.</p>
+    <p className="text-gray-600 dark:text-gray-400">Prove it. One question. No login, no judgement, no shame.</p>
   </div>
 
   <QuizBox
@@ -193,75 +193,75 @@ import {
 <div className="max-w-6xl mx-auto px-4 mb-24">
   <div className="text-center mb-12">
     <h2 className="text-3xl md:text-4xl font-bold mb-3">
-      Why this beats <s className="text-gray-600">that other course you keep restarting</s>
+      Why this beats <s className="text-gray-400 dark:text-gray-600">that other course you keep restarting</s>
     </h2>
-    <p className="text-gray-400 max-w-2xl mx-auto">
+    <p className="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
       Six choices we made on purpose to keep you coming back tomorrow.
     </p>
   </div>
 
   <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-    <div className="group p-6 rounded-2xl bg-gradient-to-br from-blue-900/20 to-gray-900/40 border border-blue-500/20 hover:border-blue-400/60 transition-all hover:-translate-y-1">
-      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-blue-500/10 border border-blue-500/30 text-blue-300 mb-4">
+    <div className="group p-6 rounded-2xl bg-gradient-to-br from-blue-50 to-white dark:from-blue-900/20 dark:to-gray-900/40 border border-blue-200 dark:border-blue-500/20 hover:border-blue-400 dark:hover:border-blue-400/60 shadow-sm dark:shadow-none transition-all hover:-translate-y-1">
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-blue-500/10 border border-blue-500/30 text-blue-700 dark:text-blue-300 mb-4">
         <LuBrain className="w-6 h-6" />
       </div>
-      <h3 className="text-xl font-bold mb-2 text-blue-300">See it. Don't memorize it.</h3>
-      <p className="text-gray-400 text-sm leading-relaxed">
+      <h3 className="text-xl font-bold mb-2 text-blue-700 dark:text-blue-300">See it. Don't memorize it.</h3>
+      <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
         Animated array shuffles. Step-by-step algorithm runners. Memory diagrams you can hover.
         The concepts that hide in textbook prose suddenly look obvious.
       </p>
     </div>
 
-    <div className="group p-6 rounded-2xl bg-gradient-to-br from-purple-900/20 to-gray-900/40 border border-purple-500/20 hover:border-purple-400/60 transition-all hover:-translate-y-1">
-      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-purple-500/10 border border-purple-500/30 text-purple-300 mb-4">
+    <div className="group p-6 rounded-2xl bg-gradient-to-br from-purple-50 to-white dark:from-purple-900/20 dark:to-gray-900/40 border border-purple-200 dark:border-purple-500/20 hover:border-purple-400 dark:hover:border-purple-400/60 shadow-sm dark:shadow-none transition-all hover:-translate-y-1">
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-purple-500/10 border border-purple-500/30 text-purple-700 dark:text-purple-300 mb-4">
         <LuZap className="w-6 h-6" />
       </div>
-      <h3 className="text-xl font-bold mb-2 text-purple-300">30 minutes. Not 30 hours.</h3>
-      <p className="text-gray-400 text-sm leading-relaxed">
+      <h3 className="text-xl font-bold mb-2 text-purple-700 dark:text-purple-300">30 minutes. Not 30 hours.</h3>
+      <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
         Each day is one sit-down. No marathon. No "come back tomorrow when you're fresh."
         One topic, one walkthrough, one set of problems. Close the laptop. Repeat tomorrow.
       </p>
     </div>
 
-    <div className="group p-6 rounded-2xl bg-gradient-to-br from-green-900/20 to-gray-900/40 border border-green-500/20 hover:border-green-400/60 transition-all hover:-translate-y-1">
-      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-green-500/10 border border-green-500/30 text-green-300 mb-4">
+    <div className="group p-6 rounded-2xl bg-gradient-to-br from-green-50 to-white dark:from-green-900/20 dark:to-gray-900/40 border border-green-200 dark:border-green-500/20 hover:border-green-400 dark:hover:border-green-400/60 shadow-sm dark:shadow-none transition-all hover:-translate-y-1">
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-green-500/10 border border-green-500/30 text-green-700 dark:text-green-300 mb-4">
         <LuTarget className="w-6 h-6" />
       </div>
-      <h3 className="text-xl font-bold mb-2 text-green-300">Shaped like the interview.</h3>
-      <p className="text-gray-400 text-sm leading-relaxed">
+      <h3 className="text-xl font-bold mb-2 text-green-700 dark:text-green-300">Shaped like the interview.</h3>
+      <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
         The patterns FAANG actually asks. Solutions in C++, Python, and Java side-by-side.
         Difficulty badges so you know what you're walking into.
       </p>
     </div>
 
-    <div className="group p-6 rounded-2xl bg-gradient-to-br from-pink-900/20 to-gray-900/40 border border-pink-500/20 hover:border-pink-400/60 transition-all hover:-translate-y-1">
-      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-pink-500/10 border border-pink-500/30 text-pink-300 mb-4">
+    <div className="group p-6 rounded-2xl bg-gradient-to-br from-pink-50 to-white dark:from-pink-900/20 dark:to-gray-900/40 border border-pink-200 dark:border-pink-500/20 hover:border-pink-400 dark:hover:border-pink-400/60 shadow-sm dark:shadow-none transition-all hover:-translate-y-1">
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-pink-500/10 border border-pink-500/30 text-pink-700 dark:text-pink-300 mb-4">
         <LuSparkles className="w-6 h-6" />
       </div>
-      <h3 className="text-xl font-bold mb-2 text-pink-300">Voice you can stand.</h3>
-      <p className="text-gray-400 text-sm leading-relaxed">
+      <h3 className="text-xl font-bold mb-2 text-pink-700 dark:text-pink-300">Voice you can stand.</h3>
+      <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
         Opinionated. Occasionally funny. Allergic to academic hedging.
         Learning that doesn't feel like a homework assignment from someone you don't like.
       </p>
     </div>
 
-    <div className="group p-6 rounded-2xl bg-gradient-to-br from-amber-900/20 to-gray-900/40 border border-amber-500/20 hover:border-amber-400/60 transition-all hover:-translate-y-1">
-      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-amber-500/10 border border-amber-500/30 text-amber-300 mb-4">
+    <div className="group p-6 rounded-2xl bg-gradient-to-br from-amber-50 to-white dark:from-amber-900/20 dark:to-gray-900/40 border border-amber-200 dark:border-amber-500/20 hover:border-amber-400 dark:hover:border-amber-400/60 shadow-sm dark:shadow-none transition-all hover:-translate-y-1">
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-amber-500/10 border border-amber-500/30 text-amber-700 dark:text-amber-300 mb-4">
         <LuLockOpen className="w-6 h-6" />
       </div>
-      <h3 className="text-xl font-bold mb-2 text-amber-300">No paywall. No signup.</h3>
-      <p className="text-gray-400 text-sm leading-relaxed">
+      <h3 className="text-xl font-bold mb-2 text-amber-700 dark:text-amber-300">No paywall. No signup.</h3>
+      <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
         Open the page. Read it. Close the tab. Skip a day. Come back in a month.
         It's a book, not a SaaS — and the source is open on GitHub.
       </p>
     </div>
 
-    <div className="group p-6 rounded-2xl bg-gradient-to-br from-teal-900/20 to-gray-900/40 border border-teal-500/20 hover:border-teal-400/60 transition-all hover:-translate-y-1">
-      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-teal-500/10 border border-teal-500/30 text-teal-300 mb-4">
+    <div className="group p-6 rounded-2xl bg-gradient-to-br from-teal-50 to-white dark:from-teal-900/20 dark:to-gray-900/40 border border-teal-200 dark:border-teal-500/20 hover:border-teal-400 dark:hover:border-teal-400/60 shadow-sm dark:shadow-none transition-all hover:-translate-y-1">
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-teal-500/10 border border-teal-500/30 text-teal-700 dark:text-teal-300 mb-4">
         <LuFlaskConical className="w-6 h-6" />
       </div>
-      <h3 className="text-xl font-bold mb-2 text-teal-300">Built for tinkerers.</h3>
-      <p className="text-gray-400 text-sm leading-relaxed">
+      <h3 className="text-xl font-bold mb-2 text-teal-700 dark:text-teal-300">Built for tinkerers.</h3>
+      <p className="text-gray-600 dark:text-gray-400 text-sm leading-relaxed">
         Every visualization is a live React component. Want to see what happens with a weird input?
         Type it in. The site bends to your curiosity.
       </p>
@@ -273,12 +273,12 @@ import {
 
 <div className="max-w-6xl mx-auto px-4 mb-24">
   <div className="text-center mb-12">
-    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-teal-500/10 border border-teal-500/30 text-xs font-medium text-teal-300 mb-4 leading-none">
+    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-teal-500/10 border border-teal-500/30 text-xs font-medium text-teal-700 dark:text-teal-300 mb-4 leading-none">
       <LuTrendingUp className="w-3.5 h-3.5 shrink-0" />
       <span>THE 30-DAY ROADMAP</span>
     </div>
     <h2 className="text-3xl md:text-4xl font-bold mb-3">Here's the whole map.</h2>
-    <p className="text-gray-400">Every tile is a self-contained day. The green dots are already written.</p>
+    <p className="text-gray-600 dark:text-gray-400">Every tile is a self-contained day. The green dots are already written.</p>
   </div>
 
   <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
@@ -317,19 +317,23 @@ import {
       <Link
         key={d}
         href={live ? `/day${d}` : "#"}
-        className={`relative group p-4 rounded-xl border ${live ? "border-gray-700 hover:border-white/40" : "border-gray-800 opacity-50 cursor-not-allowed"} bg-gray-900/40 backdrop-blur transition-all ${live ? "hover:-translate-y-1 hover:shadow-xl" : ""}`}
+        className={`relative group p-4 rounded-xl border transition-all ${
+          live
+            ? "border-gray-300 dark:border-gray-700 bg-white/90 dark:bg-gray-900/40 backdrop-blur hover:-translate-y-1 hover:shadow-lg dark:hover:shadow-xl hover:border-gray-400/60 dark:hover:border-white/40"
+            : "border-gray-200 dark:border-gray-800 bg-gray-50/80 dark:bg-gray-900/40 opacity-50 cursor-not-allowed"
+        }`}
       >
         <div className={`text-xs font-mono font-bold bg-clip-text text-transparent bg-gradient-to-r ${c} mb-1`}>
           DAY {String(d).padStart(2, "0")}
         </div>
-        <div className="text-sm font-semibold text-gray-200 leading-tight">{t}</div>
+        <div className="text-sm font-semibold text-gray-800 dark:text-gray-200 leading-tight">{t}</div>
         {live ? (
           <div className="absolute top-2 right-2 flex items-center justify-center">
             <span className="absolute w-2.5 h-2.5 rounded-full bg-green-400/40 animate-ping" />
             <span className="relative w-2 h-2 rounded-full bg-green-400 shadow shadow-green-400/50" />
           </div>
         ) : (
-          <div className="absolute top-2 right-2 text-[10px] font-mono text-gray-500">soon</div>
+          <div className="absolute top-2 right-2 text-[10px] font-mono text-gray-400 dark:text-gray-500">soon</div>
         )}
       </Link>
     ))}
@@ -340,7 +344,7 @@ import {
       <span className="w-2 h-2 rounded-full bg-green-400 shrink-0" />
       <span>live</span>
     </span>
-    <span className="text-gray-600">·</span>
+    <span className="text-gray-400">·</span>
     <span>grey = coming soon</span>
   </div>
 </div>
@@ -350,41 +354,41 @@ import {
 <div className="max-w-5xl mx-auto px-4 mb-24">
   <div className="text-center mb-12">
     <h2 className="text-3xl md:text-4xl font-bold mb-3">Every day has the same four beats.</h2>
-    <p className="text-gray-400">Predictable. Bingeable. Quietly addictive.</p>
+    <p className="text-gray-600 dark:text-gray-400">Predictable. Bingeable. Quietly addictive.</p>
   </div>
 
   <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-    <div className="p-5 rounded-xl bg-gray-900/40 border border-gray-800 hover:border-blue-500/40 transition-colors">
+    <div className="p-5 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 hover:border-blue-400 dark:hover:border-blue-500/40 shadow-sm dark:shadow-none transition-colors">
       <div className="flex items-center justify-between mb-3">
-        <div className="text-3xl font-bold text-blue-400">01</div>
-        <LuBrain className="w-5 h-5 text-blue-400/70" />
+        <div className="text-3xl font-bold text-blue-600 dark:text-blue-400">01</div>
+        <LuBrain className="w-5 h-5 text-blue-500/70 dark:text-blue-400/70" />
       </div>
       <div className="font-semibold mb-1">Intuition</div>
-      <p className="text-sm text-gray-400">An analogy. A diagram. The "wait, that's it?" moment.</p>
+      <p className="text-sm text-gray-600 dark:text-gray-400">An analogy. A diagram. The "wait, that's it?" moment.</p>
     </div>
-    <div className="p-5 rounded-xl bg-gray-900/40 border border-gray-800 hover:border-purple-500/40 transition-colors">
+    <div className="p-5 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 hover:border-purple-400 dark:hover:border-purple-500/40 shadow-sm dark:shadow-none transition-colors">
       <div className="flex items-center justify-between mb-3">
-        <div className="text-3xl font-bold text-purple-400">02</div>
-        <LuFlaskConical className="w-5 h-5 text-purple-400/70" />
+        <div className="text-3xl font-bold text-purple-600 dark:text-purple-400">02</div>
+        <LuFlaskConical className="w-5 h-5 text-purple-500/70 dark:text-purple-400/70" />
       </div>
       <div className="font-semibold mb-1">Visual walkthrough</div>
-      <p className="text-sm text-gray-400">Step through the algorithm. Pause. Rewind. Run it backwards.</p>
+      <p className="text-sm text-gray-600 dark:text-gray-400">Step through the algorithm. Pause. Rewind. Run it backwards.</p>
     </div>
-    <div className="p-5 rounded-xl bg-gray-900/40 border border-gray-800 hover:border-pink-500/40 transition-colors">
+    <div className="p-5 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 hover:border-pink-400 dark:hover:border-pink-500/40 shadow-sm dark:shadow-none transition-colors">
       <div className="flex items-center justify-between mb-3">
-        <div className="text-3xl font-bold text-pink-400">03</div>
-        <LuCode className="w-5 h-5 text-pink-400/70" />
+        <div className="text-3xl font-bold text-pink-600 dark:text-pink-400">03</div>
+        <LuCode className="w-5 h-5 text-pink-500/70 dark:text-pink-400/70" />
       </div>
       <div className="font-semibold mb-1">Code in 3 langs</div>
-      <p className="text-sm text-gray-400">C++, Python, Java side-by-side. Pick your weapon.</p>
+      <p className="text-sm text-gray-600 dark:text-gray-400">C++, Python, Java side-by-side. Pick your weapon.</p>
     </div>
-    <div className="p-5 rounded-xl bg-gray-900/40 border border-gray-800 hover:border-teal-500/40 transition-colors">
+    <div className="p-5 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 hover:border-teal-400 dark:hover:border-teal-500/40 shadow-sm dark:shadow-none transition-colors">
       <div className="flex items-center justify-between mb-3">
-        <div className="text-3xl font-bold text-teal-400">04</div>
-        <LuTarget className="w-5 h-5 text-teal-400/70" />
+        <div className="text-3xl font-bold text-teal-600 dark:text-teal-400">04</div>
+        <LuTarget className="w-5 h-5 text-teal-500/70 dark:text-teal-400/70" />
       </div>
       <div className="font-semibold mb-1">Practice + quiz</div>
-      <p className="text-sm text-gray-400">Curated interview problems. Reveal solutions when you're ready.</p>
+      <p className="text-sm text-gray-600 dark:text-gray-400">Curated interview problems. Reveal solutions when you're ready.</p>
     </div>
   </div>
 </div>
@@ -393,17 +397,17 @@ import {
 
 <div className="max-w-4xl mx-auto px-4 mb-24">
   <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-    <div className="flex items-center gap-3 p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-      <LuCircleCheck className="w-5 h-5 text-emerald-400 shrink-0" />
-      <span className="text-sm text-gray-300">Open source on GitHub</span>
+    <div className="flex items-center gap-3 p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+      <LuCircleCheck className="w-5 h-5 text-emerald-600 dark:text-emerald-400 shrink-0" />
+      <span className="text-sm text-gray-700 dark:text-gray-300">Open source on GitHub</span>
     </div>
-    <div className="flex items-center gap-3 p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-      <LuCircleCheck className="w-5 h-5 text-emerald-400 shrink-0" />
-      <span className="text-sm text-gray-300">No tracking, no ads</span>
+    <div className="flex items-center gap-3 p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+      <LuCircleCheck className="w-5 h-5 text-emerald-600 dark:text-emerald-400 shrink-0" />
+      <span className="text-sm text-gray-700 dark:text-gray-300">No tracking, no ads</span>
     </div>
-    <div className="flex items-center gap-3 p-4 rounded-xl bg-gray-900/40 border border-gray-800">
-      <LuCircleCheck className="w-5 h-5 text-emerald-400 shrink-0" />
-      <span className="text-sm text-gray-300">Updated as the curriculum evolves</span>
+    <div className="flex items-center gap-3 p-4 rounded-xl bg-white/80 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-800 shadow-sm dark:shadow-none">
+      <LuCircleCheck className="w-5 h-5 text-emerald-600 dark:text-emerald-400 shrink-0" />
+      <span className="text-sm text-gray-700 dark:text-gray-300">Updated as the curriculum evolves</span>
     </div>
   </div>
 </div>
@@ -411,28 +415,28 @@ import {
 {/* ──────────────────────── FINAL CTA ──────────────────────── */}
 
 <div className="max-w-3xl mx-auto px-4 mb-20">
-  <div className="relative overflow-hidden p-10 md:p-12 rounded-3xl bg-gradient-to-br from-blue-900/40 via-purple-900/40 to-pink-900/40 border border-purple-500/30 text-center">
-    <div className="absolute -top-10 -right-10 w-40 h-40 bg-pink-500/30 rounded-full blur-3xl" />
-    <div className="absolute -bottom-10 -left-10 w-40 h-40 bg-blue-500/30 rounded-full blur-3xl" />
+  <div className="relative overflow-hidden p-10 md:p-12 rounded-3xl bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50 dark:from-blue-900/40 dark:via-purple-900/40 dark:to-pink-900/40 border border-purple-200 dark:border-purple-500/30 text-center shadow-lg dark:shadow-none">
+    <div className="absolute -top-10 -right-10 w-40 h-40 bg-pink-400/20 dark:bg-pink-500/30 rounded-full blur-3xl" />
+    <div className="absolute -bottom-10 -left-10 w-40 h-40 bg-blue-400/20 dark:bg-blue-500/30 rounded-full blur-3xl" />
     <div className="relative">
-      <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-white/10 border border-white/20 text-white mb-5">
+      <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-blue-600/10 dark:bg-white/10 border border-blue-300 dark:border-white/20 text-blue-700 dark:text-white mb-5">
         <LuRocket className="w-7 h-7" />
       </div>
       <h2 className="text-3xl md:text-4xl font-extrabold mb-3 leading-tight">
-        The 30 days start <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-300 to-pink-300">whenever you click.</span>
+        The 30 days start <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-pink-600 dark:from-blue-300 dark:to-pink-300">whenever you click.</span>
       </h2>
-      <p className="text-gray-300 mb-7 max-w-xl mx-auto">
+      <p className="text-gray-700 dark:text-gray-300 mb-7 max-w-xl mx-auto">
         Not next Monday. Not after the holidays. Not when you "have more time."
         Right now, one tab, no setup.
       </p>
       <Link
         href="/getting_started"
-        className="group inline-flex items-center gap-2 px-8 py-4 text-base font-semibold text-white bg-white/10 hover:bg-white/20 backdrop-blur border border-white/30 rounded-full transition-all transform hover:-translate-y-0.5 hover:shadow-xl leading-none"
+        className="group inline-flex items-center gap-2 px-8 py-4 text-base font-semibold text-white bg-gradient-to-r from-blue-600 to-purple-600 hover:shadow-lg hover:shadow-blue-500/40 rounded-full transition-all transform hover:-translate-y-0.5 leading-none"
       >
         <span>Begin Day 1</span>
         <LuArrowUpRight className="w-[18px] h-[18px] shrink-0 transition-transform group-hover:translate-x-1 group-hover:-translate-y-1" />
       </Link>
-      <p className="text-xs text-gray-400 mt-5">Free · Open source · Bookmark and bail any time</p>
+      <p className="text-xs text-gray-600 dark:text-gray-400 mt-5">Free · Open source · Bookmark and bail any time</p>
     </div>
   </div>
 </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,93 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ── Component theme tokens ──────────────────────────────────────── */
+/* Used by inline-style React components (QuizBox, ArrayVisualizer, etc.)
+   so they respond to Nextra's dark-class toggle without needing useTheme. */
+
+:root {
+  --comp-surface: #fafafa;
+  --comp-surface-2: #ffffff;
+  --comp-border: #e5e7eb;
+  --comp-border-interactive: #d1d5db;
+  --comp-text: #1f2937;
+  --comp-text-2: #374151;
+  --comp-text-muted: #6b7280;
+  --comp-index-color: #9ca3af;
+  --comp-label-color: #6366f1;
+
+  --comp-selected-bg: #eef2ff;
+  --comp-selected-border: #6366f1;
+  --comp-selected-text: #4338ca;
+
+  --comp-correct-bg: #f0fdf4;
+  --comp-correct-border: #16a34a;
+  --comp-correct-text: #166534;
+
+  --comp-wrong-bg: #fef2f2;
+  --comp-wrong-border: #dc2626;
+  --comp-wrong-text: #991b1b;
+
+  --comp-cell-bg: #f9fafb;
+  --comp-cell-highlight-bg: #eef2ff;
+  --comp-cell-border: #d1d5db;
+  --comp-cell-highlight-border: #6366f1;
+  --comp-cell-text: #374151;
+  --comp-cell-highlight-text: #4338ca;
+
+  --comp-msg-bg: #f0fdf4;
+  --comp-msg-border: #bbf7d0;
+  --comp-msg-text: #166534;
+
+  --comp-input-bg: #ffffff;
+  --comp-input-border: #d1d5db;
+  --comp-input-text: #111827;
+
+  --comp-btn-text: #374151;
+  --comp-btn-border: #d1d5db;
+  --comp-btn-hover-bg: #f3f4f6;
+}
+
+html.dark {
+  --comp-surface: #1e293b;
+  --comp-surface-2: #0f172a;
+  --comp-border: #334155;
+  --comp-border-interactive: #475569;
+  --comp-text: #f1f5f9;
+  --comp-text-2: #e2e8f0;
+  --comp-text-muted: #94a3b8;
+  --comp-index-color: #64748b;
+  --comp-label-color: #818cf8;
+
+  --comp-selected-bg: #1e1b4b;
+  --comp-selected-border: #818cf8;
+  --comp-selected-text: #c7d2fe;
+
+  --comp-correct-bg: #14532d;
+  --comp-correct-border: #22c55e;
+  --comp-correct-text: #bbf7d0;
+
+  --comp-wrong-bg: #7f1d1d;
+  --comp-wrong-border: #f87171;
+  --comp-wrong-text: #fecaca;
+
+  --comp-cell-bg: #1e293b;
+  --comp-cell-highlight-bg: #1e1b4b;
+  --comp-cell-border: #334155;
+  --comp-cell-highlight-border: #818cf8;
+  --comp-cell-text: #e2e8f0;
+  --comp-cell-highlight-text: #c7d2fe;
+
+  --comp-msg-bg: #14532d;
+  --comp-msg-border: #166534;
+  --comp-msg-text: #bbf7d0;
+
+  --comp-input-bg: #0f172a;
+  --comp-input-border: #334155;
+  --comp-input-text: #f1f5f9;
+
+  --comp-btn-text: #e2e8f0;
+  --comp-btn-border: #475569;
+  --comp-btn-hover-bg: #1e293b;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ["./pages/**/*.{html,js,jsx,md,mdx}", "./components/**/*.{html,js,jsx,md,mdx}", "./templates/**/*.{html,js,jsx,md,mdx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
- tailwind.config.js: enable darkMode: 'class' so dark: variants work with Nextra's theme toggle (which applies .dark to <html>)
- styles/globals.css: add CSS custom property tokens for all component colors; :root = light defaults, html.dark = dark overrides — lets inline-style components respond to theme without useTheme hook
- components/QuizBox: switch all hardcoded hex colors to CSS variables so the quiz widget looks correct in both light and dark mode
- components/ArrayVisualizer: same CSS variable treatment for cell colors, borders, inputs, and the message banner
- components/ShowHideSolution: fix black button that disappeared in dark mode
- pages/index.mdx: full dual-mode pass on every section — replace all dark-only grays with light defaults + dark: overrides, fix badge text colors, feature card gradients and borders, roadmap tile backgrounds, CTA section gradient and button, hero secondary button, stat strip, and proof bar so nothing camouflages in light mode